### PR TITLE
to_json now can get options

### DIFF
--- a/lib/powertrack/rules/rule.rb
+++ b/lib/powertrack/rules/rule.rb
@@ -62,7 +62,7 @@ module PowerTrack
     end
 
     # Dumps the rule in a valid JSON format.
-    def to_json
+    def to_json(*options)
       MultiJson.encode(to_hash)
     end
 

--- a/lib/powertrack/rules/rule.rb
+++ b/lib/powertrack/rules/rule.rb
@@ -63,7 +63,7 @@ module PowerTrack
 
     # Dumps the rule in a valid JSON format.
     def to_json(*options)
-      MultiJson.encode(to_hash)
+      MultiJson.encode(to_hash, options)
     end
 
     # Converts the rule in a Hash.


### PR DESCRIPTION
I'm using tthe gem without active support and i get this error

ArgumentError: wrong number of arguments (1 for 0)
from /home/duncan/.rvm/gems/ruby-2.2.3/gems/powertrack-1.0.1/lib/powertrack/rules/rule.rb:65:in `to_json'
